### PR TITLE
Added z-index CSS so Tab tries to draw above other components.

### DIFF
--- a/jquery.tabSlideOut.css
+++ b/jquery.tabSlideOut.css
@@ -21,6 +21,7 @@
     background-color: white;
     padding: 0.4em;
     box-sizing: border-box;
+    z-index: 999;
 }
 .ui-slideouttab-handle {
     cursor: pointer;


### PR DESCRIPTION
Found this CSS helped it draw above other components in certain cases rather than behind it.